### PR TITLE
TypeScript: Pass `ValueType` to `Logger`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace pLog {
-	type Logger = (message: unknown) => void;
+	type Logger<T = unknown> = (message: T) => void;
 }
 
 declare const pLog: {
@@ -20,7 +20,7 @@ declare const pLog: {
 		});
 	```
 	*/
-	<ValueType>(logger?: pLog.Logger): (value: ValueType) => Promise<ValueType>;
+	<ValueType>(logger?: pLog.Logger<ValueType>): (value: ValueType) => Promise<ValueType>;
 
 	/**
 	Log the error of a promise. Use this in a `.catch()` method.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -11,6 +11,11 @@ Promise.resolve('unicorn')
 	.then(val => {
 		expectType<string>(val);
 	});
+Promise.resolve('unicorn')
+	.then(pLog(val => expectType<string>(val)))
+	.then(val => {
+		expectType<string>(val);
+	});
 
 Promise.reject(new Error('pony')).catch(pLog.catch());
 Promise.reject(new Error('pony')).catch(pLog.catch(console.dir));


### PR DESCRIPTION
This way the type is properly set for the `logger` function.

```ts
Promise.resolve('foo' as const).then(
  pLog(value => {
    console.log(value); // => Type is inferred as `'foo'`
  })
);
```